### PR TITLE
Add selections as metadata to stats output

### DIFF
--- a/src/metadata.js
+++ b/src/metadata.js
@@ -1,0 +1,31 @@
+function metadata(generatedOn, selections) {
+  if (!selections.selectedStartDate || !selections.selectedEndDate)
+    throw new Error("Date selection wasn't set.");
+
+  if (!selections.selectedAccount || !selections.selectedProperty || !selections.selectedProfile)
+    throw new Error("GA selection wasn't set.");
+
+  return {
+    metadata: {
+      generated_on: generatedOn,
+      data_start_date: selections.selectedStartDate,
+      data_end_date: selections.selectedEndDate,
+      account: {
+        id: selections.selectedAccount.id,
+        name: selections.selectedAccount.name,
+      },
+      property: {
+        id: selections.selectedProperty.id,
+        name: selections.selectedProperty.name,
+      },
+      profile: {
+        id: selections.selectedProfile.id,
+        name: selections.selectedProfile.name,
+      },
+    },
+  };
+}
+
+module.exports = {
+  metadata,
+};

--- a/tests/stats-metadata.test.js
+++ b/tests/stats-metadata.test.js
@@ -1,0 +1,37 @@
+const { metadata } = require("../src/metadata");
+
+test("should return some metadata when generating metadata given valid selections", () => {
+  const output = metadata(new Date(), createSelections());
+
+  expect(output.metadata).not.toBeFalsy();
+});
+
+test("should throw error when generating metadata given missing start date", () => {
+  expect(() => metadata(new Date(), createSelections({ selectedStartDate: undefined }))).toThrow();
+});
+
+test("should throw error when generating metadata given missing end date", () => {
+  expect(() => metadata(new Date(), createSelections({ selectedEndDate: undefined }))).toThrow();
+});
+
+test("should throw error when generating metadata given missing account", () => {
+  expect(() => metadata(new Date(), createSelections({ selectedAccount: undefined }))).toThrow();
+});
+
+test("should throw error when generating metadata given missing property", () => {
+  expect(() => metadata(new Date(), createSelections({ selectedProperty: undefined }))).toThrow();
+});
+
+test("should throw error when generating metadata given missing profile", () => {
+  expect(() => metadata(new Date(), createSelections({ selectedProfile: undefined }))).toThrow();
+});
+
+const createSelections = (opts = {}) => ({
+  selectedStartDate: getProp(opts, 'selectedStartDate', new Date("2000-01-01")),
+  selectedEndDate: getProp(opts, 'selectedEndDate', new Date("2099-01-01")),
+  selectedAccount: getProp(opts, 'selectedAccount', {}),
+  selectedProperty: getProp(opts, 'selectedProperty', {}),
+  selectedProfile: getProp(opts, 'selectedProfile', {}),
+});
+
+const getProp = (obj, prop, def) => (prop in obj ? obj[prop] : def);


### PR DESCRIPTION
Similar to #5 I wanted to be able to see the selections that were made at the time of generation so I added the user selections as metadata to the generated stats ouput, e.g.:

```
{
  ...

  "metadata": {
    "generated_on": "2018-06-15T03:50:41.205Z",
    "data_start_date": "2018-03-17T02:50:35.295Z",
    "data_end_date": "2018-06-15T03:50:35.295Z",
    "account": {
      "id": "123456789",
      "name": "Example Website"
    },
    "property": {
      "id": "UA-12341234-1",
      "name": "https://example.com"
    },
    "profile": {
      "id": "12341234",
      "name": "example.com"
    }
  }
}
```

I'm not sure about the data format. I tested the generated output with `npx browserlist` with `> 2% in my stats` and it was still able to parse it but I still think this should be considered a breaking change.

I think in a perfect world the browser stats would be nested under their own property but I'm not sure it's worth making major releases for each browserslist package to support this use case.

I'm open to ideas on a better output format, for now I'm happy to use my own fork. Just opening this in case it's useful for others.