### PR TITLE
Throw error when no GA accounts are found

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,13 @@ googleAuth(oauth2Client => {
   let selectedProfile;
 
   getAccounts(oauth2Client)
+    .then((accounts) => {
+      if (accounts.length === 0) {
+        throw new Error('No Google Analytics accounts.')
+      }
+
+      return accounts;
+    })
     .then(accounts =>
       inquirer.prompt([
         {


### PR DESCRIPTION
I ran into this error case and the user experience was really confusing because the inquirer prompt would just hang after asking me to select an account.