### PR TITLE
fix: Fix broken unit test and update tracked browsers value

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
       "test": false
     }
   },
+  "jest": {
+    "testURL": "http://localhost/"
+  },
   "devDependencies": {
     "husky": "^0.14.3",
     "jest": "^22.4.3",

--- a/tests/caniuse-agent-data.test.js
+++ b/tests/caniuse-agent-data.test.js
@@ -1,6 +1,6 @@
 var agentData = require("../src/caniuse-agent-data");
 
-test("browsers tracked are the same 18 as caniuse", () => {
+test("browsers tracked are the same 19 as caniuse", () => {
   const browsers = Object.keys(agentData);
-  expect(browsers.length).toBe(18);
+  expect(browsers.length).toBe(19);
 });


### PR DESCRIPTION
Fixes unit tests which weren't running due to a missing jest config
https://github.com/jsdom/jsdom/issues/2304

And updates the number of expected tracked browsers from `18` => `19` as per the api response from `caniuse-lite`