### PR TITLE
Updated Google OAuth requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,13 @@ Before using `browserlist-ga` you need to create an app and grant API access usi
 
 If you do not have an OAuth consent screen configured, you will need to [configure one](https://developers.google.com/workspace/guides/configure-oauth-consent). If you are not planning to publish the app to external users, you can set up Test users who will have immediate access to the app.
 
+![OAuth consent screen](https://user-images.githubusercontent.com/8075326/229480792-3452aa04-f299-4c70-bbab-dfe1f6319dca.png)
+
 2. OAuth 2.0 Client ID
 
 Once you have configured the OAuth consent screen, you need to [configure an OAuth 2.0 Client ID](https://console.cloud.google.com/apis/credentials).
+
+![OAuth 2.0 Client ID](https://user-images.githubusercontent.com/8075326/229480881-2410a122-cc43-41fb-8e02-e1dd983594bd.png)
 
 Configure the OAuth Client as a _Desktop_ App. You may give it any name you wish.
 
@@ -31,6 +35,8 @@ From the following screen, copy the Client ID and Client secret as you will need
 3. Enable Google Analytics API
 
 Finally, you are required to [enable Google Analytics API access](https://console.cloud.google.com/apis/library/analytics.googleapis.com).
+
+![Enable Google Analytics API](https://user-images.githubusercontent.com/8075326/229480950-03de62c3-8fb2-47d3-8f1f-5f01177590c9.png)
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,32 @@ Target browsers tailored to your audience.
 
 ---
 
+## Prerequisites
+
+Before using `browserlist-ga` you need to create an app and grant API access using [Google Cloud Console](https://console.cloud.google.com).
+
+1. OAuth consent screen
+
+If you do not have an OAuth consent screen configured, you will need to [configure one](https://developers.google.com/workspace/guides/configure-oauth-consent). If you are not planning to publish the app to external users, you can set up Test users who will have immediate access to the app.
+
+2. OAuth 2.0 Client ID
+
+Once you have configured the OAuth consent screen, you need to [configure an OAuth 2.0 Client ID](https://console.cloud.google.com/apis/credentials).
+
+Configure the OAuth Client as a _Desktop_ App. You may give it any name you wish.
+
+From the following screen, copy the Client ID and Client secret as you will need to input them as environment variables when running the app.
+
+3. Enable Google Analytics API
+
+Finally, you are required to [enable Google Analytics API access](https://console.cloud.google.com/apis/library/analytics.googleapis.com).
+
 ## How to use
 
 In the root directory of your project run:
 
-```yaml
-npx browserslist-ga
+```sh
+BROWSERSLIST_GA_CLIENT_ID=my_client_id.apps.googleusercontent.com BROWSERSLIST_GA_SECRET_TOKEN=my_secret npx browserslist-ga
 ```
 
 _([npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) comes with npm 5.2+, for older versions run `npm install -g browserslist-ga` and then `browserslist-ga`)_  

--- a/src/google-auth.js
+++ b/src/google-auth.js
@@ -3,20 +3,29 @@ const listen = require("./listen");
 const opener = require("opener");
 const { google } = require("googleapis");
 
-const clientId =
-  process.env.BROWSERSLIST_GA_CLIENT_ID ||
-  "343796874716-6k918h5uajk7k3apdua9n8m6her4igv7.apps.googleusercontent.com";
+const clientId = process.env.BROWSERSLIST_GA_CLIENT_ID;
 const accessToken = process.env.BROWSERSLIST_GA_ACCESS_TOKEN;
 const refreshToken = process.env.BROWSERSLIST_GA_REFRESH_TOKEN;
+const secretToken = process.env.BROWSERSLIST_GA_SECRET_TOKEN;
 
 const googleAuth = callback => {
+  if (!clientId) {
+    console.error("Please set the BROWSERSLIST_GA_CLIENT_ID environment variable.");
+    process.exit(1);
+  }
+
+  if (!secretToken) {
+    console.error("Please set the BROWSERSLIST_GA_SECRET_TOKEN environment variable.");
+    process.exit(1);
+  }
+
   portfinder.getPort((err, port) => {
     if (err) {
       return console.error(err);
     }
 
     const redirectUrl = `http://127.0.0.1:${port}`;
-    const oauth2Client = new google.auth.OAuth2(clientId, null, redirectUrl);
+    const oauth2Client = new google.auth.OAuth2(clientId, secretToken, redirectUrl);
 
     const handleAuth = (tokens, callback) => {
       oauth2Client.setCredentials(tokens);


### PR DESCRIPTION
- Removed the default BROWSERSLIST_GA_CLIENT_ID (not working well)
- Added the `client_secret` as a request parameter when calling Google APIs
- Updated README.md documentation